### PR TITLE
client/shared/utils.py: add ubifs support

### DIFF
--- a/client/shared/utils.py
+++ b/client/shared/utils.py
@@ -3164,7 +3164,7 @@ def is_mounted(src, mount_point, fstype, perm=None, verbose=True,
         fstype_mtab = fstype
 
     mount_point = os.path.realpath(mount_point)
-    if fstype not in ['nfs', 'smbfs', 'glusterfs', 'hugetlbfs']:
+    if fstype not in ['nfs', 'smbfs', 'glusterfs', 'hugetlbfs', 'ubifs']:
         if src:
             src = os.path.realpath(src)
         else:


### PR DESCRIPTION
ubifs should be treated as nfs, smbfs and so on because 'src' may be 
something like "ubi0_0", "ubi0:volumename" and so on
